### PR TITLE
Do not show titles of protected pages in the pagelist of a category

### DIFF
--- a/patch_for_MW1.22.4.txt
+++ b/patch_for_MW1.22.4.txt
@@ -740,3 +740,16 @@ diff -u -r -N includes/Title.php includes_new/Title.php
  	/**
  	 * Should links to this title be shown as potentially viewable (i.e. as
  	 * "bluelinks"), even if there's no record by this title in the page
+--- includes/CategoryViewer.php.orig	2014-04-24 23:24:36.000000000 +0200
++++ includes/CategoryViewer.php	2015-07-24 15:24:11.622529000 +0200
+@@ -331,6 +331,10 @@
+ 			$count = 0;
+ 			foreach ( $res as $row ) {
+ 				$title = Title::newFromRow( $row );
++				if (!$title->userCanReadEx()) {
++					// HaloACL: do not show titles of unreadable pages
++					continue;
++				}
+ 				if ( $row->cl_collation === '' ) {
+ 					// Hack to make sure that while updating from 1.16 schema
+ 					// and db is inconsistent, that the sky doesn't fall.

--- a/patch_for_MW1.23.4.txt
+++ b/patch_for_MW1.23.4.txt
@@ -627,3 +627,16 @@
  
  	/**
  	 * Should links to this title be shown as potentially viewable (i.e. as
+--- includes/CategoryViewer.php.orig	2014-10-29 18:57:21.000000000 +0100
++++ includes/CategoryViewer.php	2015-07-24 15:17:31.879729942 +0200
+@@ -324,6 +324,10 @@
+ 			$count = 0;
+ 			foreach ( $res as $row ) {
+ 				$title = Title::newFromRow( $row );
++				if (!$title->userCanReadEx()) {
++					// HaloACL: do not show titles of unreadable pages
++					continue;
++				}
+ 				if ( $row->cl_collation === '' ) {
+ 					// Hack to make sure that while updating from 1.16 schema
+ 					// and db is inconsistent, that the sky doesn't fall.

--- a/patch_for_MW1.23.7.txt
+++ b/patch_for_MW1.23.7.txt
@@ -636,3 +636,16 @@
  	/**
  	 * Should links to this title be shown as potentially viewable (i.e. as
  	 * "bluelinks"), even if there's no record by this title in the page
+--- includes/CategoryViewer.php.orig	2014-10-29 18:57:21.000000000 +0100
++++ includes/CategoryViewer.php	2015-07-24 15:17:31.879729942 +0200
+@@ -324,6 +324,10 @@
+ 			$count = 0;
+ 			foreach ( $res as $row ) {
+ 				$title = Title::newFromRow( $row );
++				if (!$title->userCanReadEx()) {
++					// HaloACL: do not show titles of unreadable pages
++					continue;
++				}
+ 				if ( $row->cl_collation === '' ) {
+ 					// Hack to make sure that while updating from 1.16 schema
+ 					// and db is inconsistent, that the sky doesn't fall.

--- a/patch_for_MW1.24.1.txt
+++ b/patch_for_MW1.24.1.txt
@@ -626,3 +626,16 @@
 +
 +
  }
+--- includes/CategoryViewer.php.orig	2015-07-24 15:31:32.000000000 +0200
++++ includes/CategoryViewer.php	2015-07-24 15:32:02.000000000 +0200
+@@ -336,6 +336,10 @@
+ 			$count = 0;
+ 			foreach ( $res as $row ) {
+ 				$title = Title::newFromRow( $row );
++				if (!$title->userCanReadEx()) {
++					// HaloACL: do not show titles of unreadable pages
++					continue;
++				}
+ 				if ( $row->cl_collation === '' ) {
+ 					// Hack to make sure that while updating from 1.16 schema
+ 					// and db is inconsistent, that the sky doesn't fall.


### PR DESCRIPTION
When opening a "Category:.." page a list of pages that are in this category gets displayed. 
This page list (wrongly) showed titles of pages that where otherwise protected by HaloACL!